### PR TITLE
#160 不具合解消

### DIFF
--- a/CalenderView/app/src/main/java/com/non_name_hero/calenderview/inputForm/InputBalanceActivity.kt
+++ b/CalenderView/app/src/main/java/com/non_name_hero/calenderview/inputForm/InputBalanceActivity.kt
@@ -80,6 +80,7 @@ class InputBalanceActivity  /*コンストラクタ*/
                 price.setText("")
             }
         }
+        /*クリックされたとき¥0に戻す*/
         price.setOnClickListener {
             price.setText("")
         }

--- a/CalenderView/app/src/main/res/layout/input_balance_main.xml
+++ b/CalenderView/app/src/main/res/layout/input_balance_main.xml
@@ -51,6 +51,7 @@
             android:cursorVisible="false"
             android:textAlignment="textEnd"
             android:textSize="23sp"
+            android:imeOptions="actionDone"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"


### PR DESCRIPTION
【留意点】
Enterボタンを押すと¥0になるのは修正できなかったが、そもそもスマホにはEnterキーがないため、問題なしとし、スマホのキーボード上のEnterキーを押した場合に、キーボードを閉じる処理を追加。その場合は、¥0にならないことを確認済み。