### PR TITLE
#170 家計簿入力画面の初期値を0に変更 & 数値入力タップ時にリセットする機能を削除

### DIFF
--- a/CalenderView/app/src/main/java/com/non_name_hero/calenderview/inputForm/InputBalanceActivity.kt
+++ b/CalenderView/app/src/main/java/com/non_name_hero/calenderview/inputForm/InputBalanceActivity.kt
@@ -107,12 +107,8 @@ class InputBalanceActivity  /*コンストラクタ*/
         /*金額入力テキストから離れた時*/
         price.setOnFocusChangeListener { _, hasFocus ->
             if (hasFocus) {
-                price.setText("")
+                price.setText("0")
             }
-        }
-        /*クリックされたとき¥0に戻す*/
-        price.setOnClickListener {
-            price.setText("")
         }
         /*******************************/
 
@@ -122,7 +118,7 @@ class InputBalanceActivity  /*コンストラクタ*/
             }
 
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-                var priceStr: String = ""
+                var priceStr: String = "0"
                 topZeroJudgeFlag = true
 
                 s?.asIterable()?.forEach { char ->

--- a/CalenderView/app/src/main/res/layout/input_balance_main.xml
+++ b/CalenderView/app/src/main/res/layout/input_balance_main.xml
@@ -97,6 +97,7 @@
             android:id="@+id/price"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:text="0"
             android:ems="10"
             android:inputType="number"
             android:alpha="0"


### PR DESCRIPTION
家計簿入力画面の初期値を0に変更 
数値入力タップ時にリセットする機能を削除

不具合症状は以下チケット参照
Closes #170 